### PR TITLE
Allow configuring and selecting multiple SumUp terminals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+config/config.php

--- a/README.md
+++ b/README.md
@@ -1,2 +1,47 @@
-# sumup
-Sumup
+# SumUp Terminal Web Checkout
+
+Dieses Projekt stellt eine einfache PHP-Weboberfläche bereit, mit der du den Rechnungsbetrag direkt an ein SumUp-Terminal im Netzwerk senden kannst. Damit entfällt die manuelle Eingabe am Gerät.
+
+## Voraussetzungen
+
+- PHP 8.1 oder neuer mit aktivierter cURL-Erweiterung
+- Ein SumUp-Terminal mit WLAN-Verbindung
+- Ein SumUp **Terminal API** Zugangstoken (OAuth Access Token)
+- Die Seriennummer(n) der Terminals, die Zahlungen entgegennehmen sollen
+
+## Konfiguration
+
+1. Kopiere die Datei `config/config.example.php` nach `config/config.php`.
+2. Trage dein SumUp-Zugangstoken ein und hinterlege unter `terminals` eine Liste der verwendeten Geräte (Seriennummer + Anzeigename für das Dropdown).
+3. Passe optional die Standardwährung an (ISO-4217-Code, z. B. `EUR`).
+4. Ersetze die Beispiel-Zugangsdaten durch eigene Benutzer und `password_hash`-Werte.
+5. Lege bei Bedarf einen alternativen Speicherort für das Transaktionsprotokoll fest.
+
+> Tipp: Das Access Token erhältst du über den OAuth-Client in deinem SumUp-Entwicklerkonto. Achte darauf, dass es die Berechtigung `transactions.terminal` besitzt.
+
+## Anwendung starten
+
+Starte den integrierten PHP-Server beispielsweise so:
+
+```bash
+php -S 0.0.0.0:8000 -t public
+```
+
+Rufe anschließend im Browser `http://localhost:8000` auf. Der Browser fragt nach den konfigurierten Zugangsdaten (HTTP Basic Auth). Nach erfolgreichem Login gib den Rechnungsbetrag (und optional Trinkgeld sowie eine Beschreibung) ein und klicke auf **„An Terminal senden“**. Die Anwendung erstellt eine Zahlungsanforderung über die SumUp-Terminal-API. Auf dem Gerät erscheint der Betrag zur Bestätigung.
+
+## Transaktionsprotokoll
+
+Jeder Zahlungsversuch wird mit Zeitpunkt, angemeldetem Nutzer, ausgewähltem Terminal, Betrag und Erfolg/Misserfolg in der Datei `var/transactions.log` protokolliert (oder in dem Pfad, den du in `config/config.php` angibst). Stelle sicher, dass der Webserver Schreibrechte auf dieses Verzeichnis besitzt.
+
+## Fehlerbehandlung
+
+- Bei API-Fehlern wird der HTTP-Statuscode sowie die Antwort von SumUp im Bereich „Antwortdetails“ angezeigt.
+- Prüfe bei Authentifizierungsfehlern dein Access Token und dessen Berechtigungen.
+- Stelle sicher, dass die Terminal-Seriennummer exakt mit der in deinem SumUp-Dashboard übereinstimmt.
+
+## Sicherheitshinweise
+
+- Bewahre dein Access Token sicher auf und speichere es nicht im Quelltext oder in der Versionsverwaltung.
+- Lege die Datei `config/config.php` niemals in Git ab (siehe `.gitignore`).
+- Nutze HTTPS, wenn du die Anwendung produktiv einsetzt.
+- Aktualisiere die Passworthashes regelmäßig und verwende für jeden Nutzer ein individuelles, starkes Kennwort.

--- a/config/config.example.php
+++ b/config/config.example.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'sumup' => [
+        // Generate a personal access token via https://me.sumup.com/developers
+        'access_token' => 'your-access-token-here',
+        // Default currency in ISO 4217 format
+        'currency' => 'EUR',
+        // Configure one or multiple SumUp terminals that can receive payments from the web UI
+        'terminals' => [
+            [
+                'serial' => 'ABCDEF123456',
+                'label' => 'Tresen',
+            ],
+            [
+                'serial' => 'GHIJKL987654',
+                'label' => 'Terrasse',
+            ],
+        ],
+        // Optional fallback for legacy single terminal setups:
+        // 'terminal_serial' => 'ABCDEF123456',
+        // 'terminal_label' => 'Tresen',
+    ],
+    'auth' => [
+        // Browser will display this name when prompting for credentials
+        'realm' => 'SumUp Terminal',
+        // username => password-hash pairs (use `password_hash` to generate new hashes)
+        'users' => [
+            'kasse' => '$2y$10$n9DYLqWc1jBJUniH1IpR/OYlfCfPfkKnSVYju3MrnaqwTfKRAK5wi', // password: change-me
+        ],
+    ],
+    'log' => [
+        // Absolute or relative path where transaction attempts will be appended (will be created automatically)
+        'transactions_file' => __DIR__ . '/../var/transactions.log',
+    ],
+];

--- a/public/index.php
+++ b/public/index.php
@@ -1,0 +1,470 @@
+<?php
+
+declare(strict_types=1);
+
+use SumUp\SumUpTerminalClient;
+
+require_once __DIR__ . '/../src/SumUpTerminalClient.php';
+
+$configPath = __DIR__ . '/../config/config.php';
+
+if (!file_exists($configPath)) {
+    http_response_code(500);
+    echo 'Konfigurationsdatei nicht gefunden. Bitte kopieren Sie config/config.example.php nach config/config.php.';
+    exit;
+}
+
+/**
+ * @var array{
+ *     sumup: array{
+ *         access_token?: string,
+ *         currency?: string,
+ *         terminal_serial?: string,
+ *         terminal_label?: string,
+ *         terminals?: array<int|string, array{serial?: string,label?: string}|string>
+ *     },
+ *     auth: array{realm?: string, users: array<string, string>},
+ *     log?: array{transactions_file?: string}
+ * } $config
+ */
+$config = require $configPath;
+
+$sumUpConfig = $config['sumup'] ?? [];
+$accessToken = (string) ($sumUpConfig['access_token'] ?? '');
+$defaultTerminalSerial = (string) ($sumUpConfig['terminal_serial'] ?? '');
+$defaultTerminalLabel = (string) ($sumUpConfig['terminal_label'] ?? '');
+$currency = (string) ($sumUpConfig['currency'] ?? 'EUR');
+
+$terminalOptions = [];
+
+if (isset($sumUpConfig['terminals']) && is_array($sumUpConfig['terminals'])) {
+    foreach ($sumUpConfig['terminals'] as $key => $terminalConfig) {
+        $serial = '';
+        $label = '';
+
+        if (is_array($terminalConfig)) {
+            $serial = (string) ($terminalConfig['serial'] ?? '');
+            $label = isset($terminalConfig['label']) ? (string) $terminalConfig['label'] : '';
+        } elseif (is_string($terminalConfig) || is_int($terminalConfig) || is_float($terminalConfig)) {
+            $serial = trim((string) $terminalConfig);
+            $label = is_string($key) ? trim((string) $key) : '';
+        }
+
+        if ($serial === '') {
+            continue;
+        }
+
+        if ($label === '') {
+            $label = $serial;
+        }
+
+        $terminalOptions[$serial] = $label;
+    }
+}
+
+if ($terminalOptions === [] && $defaultTerminalSerial !== '') {
+    $label = $defaultTerminalLabel !== '' ? $defaultTerminalLabel : $defaultTerminalSerial;
+    $terminalOptions[$defaultTerminalSerial] = $label;
+}
+
+$selectedTerminalSerial = array_key_first($terminalOptions) ?? '';
+$selectedTerminalLabel = $selectedTerminalSerial !== '' ? $terminalOptions[$selectedTerminalSerial] : '';
+
+$logConfig = $config['log'] ?? [];
+$transactionsLogFile = (string) ($logConfig['transactions_file'] ?? (__DIR__ . '/../var/transactions.log'));
+
+$authConfig = $config['auth'] ?? [];
+$authRealm = (string) ($authConfig['realm'] ?? 'SumUp Terminal');
+$authUsers = $authConfig['users'] ?? [];
+
+if ($authUsers === []) {
+    http_response_code(500);
+    echo 'Keine Benutzer für den Zugriff konfiguriert. Bitte ergänzen Sie config/config.php.';
+    exit;
+}
+
+$authenticated = false;
+$username = '';
+
+if (isset($_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW'])) {
+    $username = (string) $_SERVER['PHP_AUTH_USER'];
+    $password = (string) $_SERVER['PHP_AUTH_PW'];
+
+    if (array_key_exists($username, $authUsers)) {
+        $storedHash = (string) $authUsers[$username];
+        $authenticated = password_verify($password, $storedHash)
+            || hash_equals($storedHash, $password);
+    }
+}
+
+if ($authenticated === false) {
+    header('WWW-Authenticate: Basic realm="' . addslashes($authRealm) . '", charset="UTF-8"');
+    http_response_code(401);
+    echo 'Authentifizierung erforderlich.';
+    exit;
+}
+
+$error = null;
+$result = null;
+$logError = null;
+
+/**
+ * @param string $logFile
+ * @param string $username
+ * @param float  $amount
+ * @param bool   $success
+ * @param string $terminalSerial
+ * @param string $terminalLabel
+ */
+function writeTransactionLog(
+    string $logFile,
+    string $username,
+    float $amount,
+    bool $success,
+    string $terminalSerial,
+    string $terminalLabel = ''
+): bool
+{
+    $directory = dirname($logFile);
+
+    if ($directory !== '' && !is_dir($directory)) {
+        if (!mkdir($directory, 0775, true) && !is_dir($directory)) {
+            return false;
+        }
+    }
+
+    $terminalInfo = '-';
+
+    if ($terminalSerial !== '') {
+        $terminalInfo = $terminalSerial;
+
+        if ($terminalLabel !== '' && $terminalLabel !== $terminalSerial) {
+            $terminalInfo = sprintf('%s (%s)', $terminalLabel, $terminalSerial);
+        }
+    }
+
+    $line = sprintf(
+        "%s\t%s\t%s\t%s\t%s\n",
+        (new DateTimeImmutable('now'))->format('c'),
+        $username !== '' ? $username : '-',
+        $terminalInfo,
+        number_format($amount, 2, '.', ''),
+        $success ? 'success' : 'failure'
+    );
+
+    return file_put_contents($logFile, $line, FILE_APPEND | LOCK_EX) !== false;
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $amount = isset($_POST['amount']) ? (float) str_replace(',', '.', (string) $_POST['amount']) : 0.0;
+    $tipAmount = isset($_POST['tip_amount']) && $_POST['tip_amount'] !== ''
+        ? (float) str_replace(',', '.', (string) $_POST['tip_amount'])
+        : null;
+    $description = isset($_POST['description']) ? trim((string) $_POST['description']) : null;
+    $requestedTerminalSerial = isset($_POST['terminal_serial']) ? trim((string) $_POST['terminal_serial']) : '';
+    $externalId = sprintf('web-%s', bin2hex(random_bytes(4)));
+
+    $paymentSuccessful = false;
+
+    if ($terminalOptions === []) {
+        $error = 'Es ist kein SumUp-Terminal konfiguriert.';
+    } elseif ($requestedTerminalSerial !== '') {
+        if (array_key_exists($requestedTerminalSerial, $terminalOptions)) {
+            $selectedTerminalSerial = $requestedTerminalSerial;
+            $selectedTerminalLabel = $terminalOptions[$requestedTerminalSerial];
+        } else {
+            $error = 'Ausgewähltes Terminal ist ungültig oder nicht konfiguriert.';
+        }
+    } elseif (count($terminalOptions) > 1) {
+        $error = 'Bitte wählen Sie ein Terminal aus.';
+    }
+
+    if ($error === null) {
+        try {
+            $client = new SumUpTerminalClient($accessToken, $selectedTerminalSerial);
+            $response = $client->sendPayment($amount, $currency, $externalId, $description, $tipAmount);
+
+            if ($response['status'] >= 200 && $response['status'] < 300) {
+                $paymentSuccessful = true;
+                $terminalDisplayName = $selectedTerminalLabel !== '' ? $selectedTerminalLabel : $selectedTerminalSerial;
+                $result = [
+                    'title' => 'Zahlungsanforderung gesendet',
+                    'message' => $terminalDisplayName !== ''
+                        ? sprintf(
+                            'Der Betrag wurde an das Terminal "%s" übertragen. Warten Sie auf die Bestätigung auf dem Gerät.',
+                            $terminalDisplayName
+                        )
+                        : 'Der Betrag wurde an das Terminal übertragen. Warten Sie auf die Bestätigung auf dem Gerät.',
+                    'details' => $response['body'],
+                ];
+            } else {
+                $error = sprintf(
+                    'Fehler beim Senden der Zahlungsanforderung (HTTP %d).',
+                    $response['status']
+                );
+                $result = [
+                    'title' => 'Antwort des SumUp-Servers',
+                    'details' => $response['body'],
+                ];
+            }
+        } catch (Throwable $exception) {
+            $error = $exception->getMessage();
+        }
+    }
+
+    if (!writeTransactionLog(
+        $transactionsLogFile,
+        $username,
+        $amount,
+        $paymentSuccessful,
+        $selectedTerminalSerial,
+        $selectedTerminalLabel
+    )) {
+        $logError = 'Transaktionsprotokoll konnte nicht geschrieben werden. Bitte überprüfen Sie die Schreibrechte.';
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="utf-8">
+    <title>SumUp Terminal Zahlung</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+        :root {
+            color-scheme: light dark;
+            font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+        }
+
+        body {
+            margin: 0;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 100vh;
+            background: #f6f8fb;
+        }
+
+        .container {
+            background: #fff;
+            padding: 2rem;
+            border-radius: 1rem;
+            box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.15);
+            max-width: 32rem;
+            width: 90%;
+        }
+
+        h1 {
+            margin-top: 0;
+            margin-bottom: 1.5rem;
+            font-size: 1.75rem;
+            color: #111827;
+        }
+
+        form {
+            display: grid;
+            gap: 1rem;
+        }
+
+        label {
+            display: flex;
+            flex-direction: column;
+            font-weight: 600;
+            color: #374151;
+        }
+
+        input,
+        select,
+        textarea {
+            margin-top: 0.35rem;
+            padding: 0.75rem 1rem;
+            border-radius: 0.75rem;
+            border: 1px solid #d1d5db;
+            font-size: 1rem;
+        }
+
+        textarea {
+            min-height: 4rem;
+            resize: vertical;
+        }
+
+        button {
+            background: #2563eb;
+            color: #fff;
+            border: none;
+            border-radius: 999px;
+            padding: 0.85rem 1.5rem;
+            font-size: 1rem;
+            font-weight: 600;
+            cursor: pointer;
+            transition: background 0.2s ease-in-out;
+        }
+
+        button:hover,
+        button:focus {
+            background: #1d4ed8;
+        }
+
+        .alert {
+            border-radius: 0.75rem;
+            padding: 1rem 1.25rem;
+            margin-bottom: 1rem;
+        }
+
+        .alert.error {
+            background: #fee2e2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .alert.success {
+            background: #dcfce7;
+            color: #166534;
+            border: 1px solid #bbf7d0;
+        }
+
+        pre {
+            background: #0f172a;
+            color: #e2e8f0;
+            padding: 1rem;
+            border-radius: 0.75rem;
+            overflow-x: auto;
+            font-size: 0.85rem;
+        }
+
+        @media (prefers-color-scheme: dark) {
+            body {
+                background: #0f172a;
+            }
+
+            .container {
+                background: #111827;
+                color: #f9fafb;
+                box-shadow: none;
+                border: 1px solid #1f2937;
+            }
+
+            h1 {
+                color: #f3f4f6;
+            }
+
+            label {
+                color: #d1d5db;
+            }
+
+            input,
+            select,
+            textarea {
+                background: #1f2937;
+                color: #f9fafb;
+                border: 1px solid #374151;
+            }
+
+            .alert.success {
+                background: rgba(22, 101, 52, 0.2);
+                border-color: rgba(22, 101, 52, 0.4);
+            }
+
+            .alert.error {
+                background: rgba(153, 27, 27, 0.2);
+                border-color: rgba(153, 27, 27, 0.4);
+            }
+
+            pre {
+                background: #1e293b;
+                color: #e2e8f0;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>SumUp Zahlung starten</h1>
+        <?php if ($error !== null): ?>
+            <div class="alert error">
+                <strong>Fehler:</strong>
+                <div><?= htmlspecialchars($error, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?></div>
+            </div>
+        <?php elseif ($result !== null): ?>
+            <div class="alert success">
+                <strong><?= htmlspecialchars($result['title'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?></strong>
+                <p><?= htmlspecialchars($result['message'] ?? '', ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?></p>
+            </div>
+        <?php endif; ?>
+
+        <?php if ($logError !== null): ?>
+            <div class="alert error">
+                <strong>Protokollierung:</strong>
+                <div><?= htmlspecialchars($logError, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?></div>
+            </div>
+        <?php endif; ?>
+
+        <form method="post">
+            <?php if ($terminalOptions === []): ?>
+                <label>
+                    Terminal
+                    <select name="terminal_serial" disabled>
+                        <option>Bitte konfigurieren Sie mindestens ein Terminal</option>
+                    </select>
+                </label>
+            <?php else: ?>
+                <label>
+                    Terminal
+                    <select name="terminal_serial">
+                        <?php foreach ($terminalOptions as $serial => $label): ?>
+                            <option value="<?= htmlspecialchars($serial, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>"<?= $serial === $selectedTerminalSerial ? ' selected' : '' ?>>
+                                <?= htmlspecialchars($label, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>
+                            </option>
+                        <?php endforeach; ?>
+                    </select>
+                </label>
+            <?php endif; ?>
+
+            <label>
+                Rechnungsbetrag (<?= htmlspecialchars($currency, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>)
+                <input
+                    type="number"
+                    name="amount"
+                    min="0"
+                    step="0.01"
+                    placeholder="z. B. 19.99"
+                    value="<?= isset($_POST['amount']) ? htmlspecialchars((string) $_POST['amount'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') : '' ?>"
+                    required
+                >
+            </label>
+
+            <label>
+                Trinkgeld (optional)
+                <input
+                    type="number"
+                    name="tip_amount"
+                    min="0"
+                    step="0.01"
+                    placeholder="z. B. 2.00"
+                    value="<?= isset($_POST['tip_amount']) ? htmlspecialchars((string) $_POST['tip_amount'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') : '' ?>"
+                >
+            </label>
+
+            <label>
+                Beschreibung (optional)
+                <textarea name="description" placeholder="Referenz oder Notiz"><?= isset($_POST['description']) ? htmlspecialchars((string) $_POST['description'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') : '' ?></textarea>
+            </label>
+
+            <button type="submit"<?= $terminalOptions === [] ? ' disabled' : '' ?>>An Terminal senden</button>
+        </form>
+
+        <?php if ($result !== null): ?>
+            <details>
+                <summary>Antwortdetails</summary>
+                <pre><?= htmlspecialchars(json_encode($result['details'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE), ENT_NOQUOTES | ENT_SUBSTITUTE, 'UTF-8') ?></pre>
+            </details>
+        <?php endif; ?>
+
+        <?php if ($accessToken === '' || $terminalOptions === []): ?>
+            <p class="alert error">
+                Bitte hinterlegen Sie den Zugriffstoken und mindestens ein Terminal in <code>config/config.php</code>.
+            </p>
+        <?php endif; ?>
+    </div>
+</body>
+</html>

--- a/src/SumUpTerminalClient.php
+++ b/src/SumUpTerminalClient.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SumUp;
+
+use RuntimeException;
+
+final class SumUpTerminalClient
+{
+    private const API_BASE_URL = 'https://api.sumup.com/v0.1';
+
+    public function __construct(
+        private readonly string $accessToken,
+        private readonly string $terminalSerial
+    ) {
+        if ($accessToken === '') {
+            throw new RuntimeException('Missing SumUp access token.');
+        }
+
+        if ($terminalSerial === '') {
+            throw new RuntimeException('Missing SumUp terminal serial number.');
+        }
+    }
+
+    /**
+     * Sends a payment request to the configured SumUp terminal.
+     *
+     * @param float       $amount       Amount in major units (e.g. Euros).
+     * @param string      $currency     ISO 4217 currency code, e.g. "EUR".
+     * @param string|null $externalId   Optional unique identifier for the payment.
+     * @param string|null $description  Optional description that appears in SumUp dashboard.
+     * @param float|null  $tipAmount    Optional tip amount in major units.
+     *
+     * @return array{status:int, body:array<string,mixed>}
+     */
+    public function sendPayment(
+        float $amount,
+        string $currency = 'EUR',
+        ?string $externalId = null,
+        ?string $description = null,
+        ?float $tipAmount = null
+    ): array {
+        if ($amount <= 0) {
+            throw new RuntimeException('Amount must be greater than zero.');
+        }
+
+        $payload = [
+            'amount' => round($amount, 2),
+            'currency' => strtoupper($currency),
+            'transaction_type' => 'SALE',
+        ];
+
+        if ($tipAmount !== null) {
+            $payload['tip_amount'] = round($tipAmount, 2);
+        }
+
+        if ($externalId !== null && $externalId !== '') {
+            $payload['external_id'] = $externalId;
+        }
+
+        if ($description !== null && $description !== '') {
+            $payload['description'] = $description;
+        }
+
+        $endpoint = sprintf(
+            '%s/terminals/%s/transactions',
+            self::API_BASE_URL,
+            rawurlencode($this->terminalSerial)
+        );
+
+        return $this->postJson($endpoint, $payload);
+    }
+
+    /**
+     * @param array<string,mixed> $payload
+     * @return array{status:int, body:array<string,mixed>}
+     */
+    private function postJson(string $url, array $payload): array
+    {
+        $ch = curl_init($url);
+        if ($ch === false) {
+            throw new RuntimeException('Unable to initialise cURL.');
+        }
+
+        $encodedPayload = json_encode($payload, JSON_THROW_ON_ERROR);
+
+        curl_setopt_array($ch, [
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_POST => true,
+            CURLOPT_POSTFIELDS => $encodedPayload,
+            CURLOPT_HTTPHEADER => [
+                'Content-Type: application/json',
+                'Accept: application/json',
+                'Authorization: Bearer ' . $this->accessToken,
+            ],
+        ]);
+
+        $responseBody = curl_exec($ch);
+        if ($responseBody === false) {
+            $message = curl_error($ch);
+            curl_close($ch);
+            throw new RuntimeException('SumUp API request failed: ' . $message);
+        }
+
+        $statusCode = curl_getinfo($ch, CURLINFO_RESPONSE_CODE) ?: 0;
+        curl_close($ch);
+
+        /** @var array<string,mixed>|null $decoded */
+        $decoded = json_decode($responseBody, true);
+        if (!is_array($decoded)) {
+            $decoded = [
+                'raw' => $responseBody,
+            ];
+        }
+
+        return [
+            'status' => $statusCode,
+            'body' => $decoded,
+        ];
+    }
+}

--- a/var/.gitignore
+++ b/var/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
## Summary
- allow configuring multiple SumUp terminals and choose them from the web UI
- update the example configuration and README for the new terminals list
- include the selected terminal in transaction log entries

## Testing
- php -l public/index.php
- php -l src/SumUpTerminalClient.php

------
https://chatgpt.com/codex/tasks/task_e_68db9b2aade0833392f49c7b5279b3e2