### PR TITLE
Surface terminal configuration warnings in checkout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+config/config.php

--- a/README.md
+++ b/README.md
@@ -1,2 +1,90 @@
-# sumup
-Sumup
+# SumUp Terminal Web Checkout
+
+Dieses Projekt stellt eine einfache PHP-Weboberfläche bereit, mit der du den Rechnungsbetrag direkt an ein SumUp-Terminal im Netzwerk senden kannst. Damit entfällt die manuelle Eingabe am Gerät.
+
+## Voraussetzungen
+
+- PHP 8.1 oder neuer mit aktivierter cURL-Erweiterung
+- PHP-Erweiterung [libsodium](https://www.php.net/manual/de/book.sodium.php) für die verschlüsselte Schlüsselablage
+- Ein SumUp-Terminal mit WLAN-Verbindung
+- Ein SumUp **Terminal API** API-Key **oder** OAuth-Access-Token
+- Die Seriennummer(n) der Terminals, die Zahlungen entgegennehmen sollen
+
+## Konfiguration
+
+1. Kopiere die Datei `config/config.example.php` nach `config/config.php`.
+2. Lege fest, ob du dich mit einem API-Key (`auth_method = "api_key"`) oder einem OAuth-Token (`auth_method = "oauth"`) authentifizieren möchtest. Wenn du den API-Key nicht direkt in der Konfigurationsdatei speichern willst, lasse das Feld `api_key` leer und hinterlege den Schlüssel später sicher über `public/anmeldung.php`.
+3. Trage deine SumUp-Terminals unter `sumup.terminals` ein. Erlaubte Formate:
+   - Numerisches Array von Objekten mit `serial` und optional `label` (wie im Beispiel).
+   - Assoziatives Array mit der Seriennummer als Schlüssel und einer Kurzbeschreibung als Wert.
+   - Assoziatives Array mit der Seriennummer als Schlüssel und einem Array mit zusätzlichen Angaben, etwa `['label' => 'Tresen']`.
+   Leerzeichen werden automatisch entfernt; fehlende Labels werden durch die Seriennummer ersetzt.
+   Sollte das Dashboard weiterhin keine Auswahl anbieten, prüfe die gelben Konfigurationshinweise oberhalb des Formulars – sie nennen die betroffenen Einträge in `config/config.php`.
+4. Passe optional die Standardwährung an (ISO-4217-Code, z. B. `EUR`).
+5. Ersetze die Beispiel-Zugangsdaten durch eigene Benutzer und `password_hash`-Werte.
+6. Lege bei Bedarf einen alternativen Speicherort für das Transaktionsprotokoll fest.
+7. (Optional) Passe die Pfade des verschlüsselten Credential-Stores (`secure_store`) an, falls du die Dateien an einem anderen Ort ablegen möchtest.
+
+> Tipp: Den API-Key findest du unter <https://me.sumup.com/developers>. Melde dich dort mit deinem Händlerkonto an, wähle **„Personal Access Tokens“** aus, erstelle bei Bedarf einen neuen Token und kopiere den angezeigten Schlüssel in die Konfiguration. Das OAuth-Access-Token erzeugst du im gleichen Bereich über deinen OAuth-Client.
+
+## API-Key sicher speichern
+
+Anstatt den SumUp-API-Key in `config/config.php` abzulegen, kannst du ihn nach der Einrichtung über `http://localhost:8000/anmeldung.php` sicher hinterlegen:
+
+1. Melde dich mit den in der Konfiguration hinterlegten Zugangsdaten (HTTP Basic Auth) an.
+2. Trage optional eine Referenz (z. B. deine Händler-E-Mail) ein und füge den SumUp-API-Key ein.
+3. Nach dem Speichern verschlüsselt die Anwendung den Schlüssel mit der PHP-Erweiterung **libsodium** (`sodium`) und legt ihn in `var/sumup_credentials.json` ab; der dazugehörige Schlüssel liegt in `var/secure_store.key`.
+4. Kehre zur Kasse (`index.php`) zurück. Die Anwendung lädt den Schlüssel automatisch und zeigt an, wann er zuletzt aktualisiert wurde.
+
+Zum Löschen des gespeicherten API-Keys nutze die entsprechende Schaltfläche in `anmeldung.php`. Achte darauf, dass dein Webserver Schreibrechte auf das `var/`-Verzeichnis besitzt.
+
+## Authentifizierung bei SumUp
+
+SumUp unterstützt für den Terminal-API-Zugriff zwei Verfahren:
+
+- **API-Key („Personal Access Token“)** – geeignet, wenn du ausschließlich für dein eigenes Händlerkonto arbeitest. Wähle in der Konfiguration `auth_method = "api_key"` und trage den API-Key ein.
+- **OAuth 2.0 Access Token** – erforderlich, wenn deine Anwendung im Namen anderer Händler agiert oder du eine Plattform betreibst. Setze `auth_method = "oauth"` und hinterlege das Access Token.
+
+### Erforderliche OAuth-Berechtigungen
+
+Falls du OAuth verwendest, muss dein Client mindestens den Scope `transactions.terminal` erhalten. Ohne diese Berechtigung schlägt das Pushen des Betrags auf das Gerät mit einem HTTP-Fehler 403 fehl.
+
+### Ablauf der Transaktion
+
+Die Weboberfläche stößt serverseitig einen Request an den SumUp-Readers/Cloud-Endpunkt an, der das SumUp-Solo-Terminal anweist, den Betrag anzuzeigen. Der endgültige Status (bezahlt, abgebrochen usw.) wird von SumUp asynchron über Webhooks gemeldet – richte daher im SumUp-Dashboard die passenden Webhook-URLs ein, wenn du Transaktionen automatisiert weiterverarbeiten möchtest.
+
+### Gibt es Alternativen zu OAuth?
+
+Ja: Wenn du nur für dein eigenes Händlerkonto arbeitest, kannst du statt OAuth den SumUp-API-Key verwenden. Für Plattform-Szenarien mit mehreren Händlerkonten bleibt OAuth 2.0 die einzige Option.
+
+### Warum helfen Webhooks nicht weiter?
+
+Webhooks sind bei SumUp ausschließlich dafür gedacht, dich **über bereits stattgefundene Ereignisse** (z. B. abgeschlossene Zahlungen) zu informieren. Sie können **keine** Zahlungsanforderung an ein Terminal auslösen oder Beträge an das Gerät „pushen“. Um einen Betrag proaktiv auf ein Terminal zu schicken, benötigst du zwingend einen authentifizierten Aufruf der Terminal-API mit deinem API-Key oder einem OAuth-Access-Token.
+
+## Anwendung starten
+
+Starte den integrierten PHP-Server beispielsweise so:
+
+```bash
+php -S 0.0.0.0:8000 -t public
+```
+
+Rufe anschließend im Browser `http://localhost:8000` auf. Der Browser fragt nach den konfigurierten Zugangsdaten (HTTP Basic Auth). Nach erfolgreichem Login gib den Rechnungsbetrag (und optional Trinkgeld sowie eine Beschreibung) ein und klicke auf **„An Terminal senden“**. Die Anwendung erstellt eine Zahlungsanforderung über die SumUp-Terminal-API. Auf dem Gerät erscheint der Betrag zur Bestätigung.
+
+## Transaktionsprotokoll
+
+Jeder Zahlungsversuch wird mit Zeitpunkt, angemeldetem Nutzer, ausgewähltem Terminal, Betrag und Erfolg/Misserfolg in der Datei `var/transactions.log` protokolliert (oder in dem Pfad, den du in `config/config.php` angibst). Stelle sicher, dass der Webserver Schreibrechte auf dieses Verzeichnis besitzt.
+
+## Fehlerbehandlung
+
+- Bei API-Fehlern wird der HTTP-Statuscode sowie die Antwort von SumUp im Bereich „Antwortdetails“ angezeigt.
+- Prüfe bei Authentifizierungsfehlern dein Access Token und dessen Berechtigungen.
+- Stelle sicher, dass die Terminal-Seriennummer exakt mit der in deinem SumUp-Dashboard übereinstimmt.
+- Erscheint nach dem Absenden lediglich eine weiße Seite, fehlt meist die PHP-Extension `curl`. Installiere sie auf deinem Server (unter Debian/Ubuntu z. B. `sudo apt install php-curl`) und starte PHP danach neu.
+
+## Sicherheitshinweise
+
+- Bewahre dein Access Token sicher auf und speichere es nicht im Quelltext oder in der Versionsverwaltung.
+- Lege die Datei `config/config.php` niemals in Git ab (siehe `.gitignore`).
+- Nutze HTTPS, wenn du die Anwendung produktiv einsetzt.
+- Aktualisiere die Passworthashes regelmäßig und verwende für jeden Nutzer ein individuelles, starkes Kennwort.

--- a/config/config.example.php
+++ b/config/config.example.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'sumup' => [
+        // Choose whether you authenticate with an API key (own account) or an OAuth access token (multi-merchant platforms)
+        'auth_method' => 'api_key', // allowed values: api_key, oauth
+        // Leave blank when you store the key via public/anmeldung.php
+        'api_key' => '',
+        // For OAuth set auth_method to "oauth" and place the access token below instead
+        'access_token' => 'your-oauth-access-token-here',
+        // Default currency in ISO 4217 format
+        'currency' => 'EUR',
+        // Configure one or multiple SumUp terminals that can receive payments from the web UI
+        // You can either provide a numerically indexed list as below or use the serial number as array key
+        'terminals' => [
+            [
+                'serial' => 'ABCDEF123456',
+                'label' => 'Tresen',
+            ],
+            [
+                'serial' => 'GHIJKL987654',
+                'label' => 'Terrasse',
+            ],
+            // 'ABCDEF123456' => [
+            //     'label' => 'Tresen',
+            // ],
+            // 'GHIJKL987654' => 'Terrasse',
+        ],
+        // Optional fallback for legacy single terminal setups:
+        // 'terminal_serial' => 'ABCDEF123456',
+        // 'terminal_label' => 'Tresen',
+    ],
+    'auth' => [
+        // Browser will display this name when prompting for credentials
+        'realm' => 'SumUp Terminal',
+        // username => password-hash pairs (use `password_hash` to generate new hashes)
+        'users' => [
+            'kasse' => '$2y$10$n9DYLqWc1jBJUniH1IpR/OYlfCfPfkKnSVYju3MrnaqwTfKRAK5wi', // password: change-me
+        ],
+    ],
+    'log' => [
+        // Absolute or relative path where transaction attempts will be appended (will be created automatically)
+        'transactions_file' => __DIR__ . '/../var/transactions.log',
+    ],
+    'secure_store' => [
+        // Files used by the encrypted credential store (not committed to Git)
+        'credential_file' => __DIR__ . '/../var/sumup_credentials.json',
+        'key_file' => __DIR__ . '/../var/secure_store.key',
+    ],
+];

--- a/public/anmeldung.php
+++ b/public/anmeldung.php
@@ -1,0 +1,408 @@
+<?php
+
+declare(strict_types=1);
+
+use SumUp\BasicAuth;
+use SumUp\CredentialStore;
+
+require_once __DIR__ . '/../src/BasicAuth.php';
+require_once __DIR__ . '/../src/CredentialStore.php';
+
+function renderFatalError(string $message, int $statusCode = 500): void
+{
+    http_response_code($statusCode);
+    header('Content-Type: text/html; charset=UTF-8');
+
+    $safeMessage = htmlspecialchars($message, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+
+    echo <<<HTML
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="utf-8">
+    <title>Fehler – SumUp Zugang</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+        :root {
+            color-scheme: light dark;
+            font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+        }
+
+        body {
+            margin: 0;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 100vh;
+            background: #0f172a;
+            color: #f9fafb;
+            padding: 2rem;
+        }
+
+        .card {
+            background: #111827;
+            border-radius: 1rem;
+            padding: 2.5rem 2rem;
+            max-width: 32rem;
+            box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.35);
+        }
+
+        h1 {
+            margin-top: 0;
+            margin-bottom: 1rem;
+            font-size: 1.75rem;
+        }
+
+        p {
+            margin: 0;
+            line-height: 1.6;
+        }
+    </style>
+</head>
+<body>
+    <div class="card">
+        <h1>Es ist ein Fehler aufgetreten</h1>
+        <p>{$safeMessage}</p>
+    </div>
+</body>
+</html>
+HTML;
+
+    exit;
+}
+
+$configPath = __DIR__ . '/../config/config.php';
+
+if (!file_exists($configPath)) {
+    renderFatalError('Konfigurationsdatei nicht gefunden. Bitte kopieren Sie config/config.example.php nach config/config.php.');
+}
+
+/**
+ * @var mixed $config
+ */
+$config = require $configPath;
+
+if (!is_array($config)) {
+    renderFatalError('Die Konfigurationsdatei muss ein Array zurückgeben. Bitte prüfen Sie config/config.php.');
+}
+
+foreach (['auth', 'secure_store'] as $section) {
+    if (isset($config[$section]) && !is_array($config[$section])) {
+        renderFatalError(sprintf('Der Abschnitt "%s" muss ein Array sein. Bitte korrigieren Sie config/config.php.', $section));
+    }
+}
+
+/**
+ * @var array{
+ *     auth?: array{realm?: string, users?: array<string, string>},
+ *     secure_store?: array{credential_file?: string, key_file?: string}
+ * } $config
+ */
+
+$authConfig = $config['auth'] ?? [];
+$authenticatedUser = BasicAuth::enforce($authConfig);
+
+$secureStoreConfig = $config['secure_store'] ?? [];
+$store = null;
+$storeError = null;
+$successMessage = null;
+$errorMessage = null;
+$storedCredential = null;
+
+if (!isset($secureStoreConfig['credential_file'], $secureStoreConfig['key_file'])) {
+    $storeError = 'In der Konfiguration fehlen die Pfade für die sichere Ablage (secure_store.credential_file/key_file).';
+} else {
+    try {
+        $store = new CredentialStore(
+            (string) $secureStoreConfig['credential_file'],
+            (string) $secureStoreConfig['key_file']
+        );
+        $storedCredential = $store->getApiCredential();
+    } catch (Throwable $exception) {
+        $storeError = $exception->getMessage();
+    }
+}
+
+if ($store instanceof CredentialStore && $_SERVER['REQUEST_METHOD'] === 'POST') {
+    $action = isset($_POST['action']) ? (string) $_POST['action'] : 'save';
+
+    if ($action === 'clear') {
+        $store->clear();
+        $storedCredential = null;
+        $successMessage = 'Der gespeicherte API-Key wurde entfernt.';
+    } else {
+        $merchantId = isset($_POST['merchant_id']) ? trim((string) $_POST['merchant_id']) : '';
+        $apiKey = isset($_POST['api_key']) ? (string) $_POST['api_key'] : '';
+
+        try {
+            $store->saveApiKey($merchantId, $apiKey);
+            $storedCredential = $store->getApiCredential();
+            $successMessage = 'API-Key wurde sicher gespeichert und steht jetzt in der Anwendung zur Verfügung.';
+        } catch (Throwable $exception) {
+            $errorMessage = $exception->getMessage();
+        }
+    }
+}
+
+function escape(string $value): string
+{
+    return htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+}
+?>
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="utf-8">
+    <title>SumUp API-Key hinterlegen</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+        :root {
+            color-scheme: light dark;
+            font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+        }
+
+        body {
+            margin: 0;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 100vh;
+            background: #f4f4f8;
+        }
+
+        .panel {
+            background: #ffffff;
+            padding: 2.5rem 2rem;
+            border-radius: 1rem;
+            box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.1);
+            max-width: 36rem;
+            width: 92%;
+        }
+
+        h1 {
+            margin-top: 0;
+            color: #111827;
+            font-size: 1.75rem;
+        }
+
+        p {
+            color: #4b5563;
+            line-height: 1.6;
+        }
+
+        form {
+            display: grid;
+            gap: 1rem;
+            margin-top: 1.5rem;
+        }
+
+        label {
+            display: flex;
+            flex-direction: column;
+            font-weight: 600;
+            color: #374151;
+        }
+
+        input {
+            margin-top: 0.4rem;
+            padding: 0.8rem 1rem;
+            border-radius: 0.75rem;
+            border: 1px solid #d1d5db;
+            font-size: 1rem;
+        }
+
+        button {
+            background: #2563eb;
+            color: #fff;
+            border: none;
+            border-radius: 999px;
+            padding: 0.9rem 1.5rem;
+            font-size: 1rem;
+            font-weight: 600;
+            cursor: pointer;
+            transition: background 0.2s ease-in-out;
+        }
+
+        button:hover,
+        button:focus {
+            background: #1d4ed8;
+        }
+
+        .button-danger {
+            background: #dc2626;
+        }
+
+        .button-danger:hover,
+        .button-danger:focus {
+            background: #b91c1c;
+        }
+
+        .alert {
+            border-radius: 0.75rem;
+            padding: 1rem 1.25rem;
+            margin-bottom: 1rem;
+        }
+
+        .alert.error {
+            background: #fee2e2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .alert.success {
+            background: #dcfce7;
+            color: #166534;
+            border: 1px solid #bbf7d0;
+        }
+
+        .alert.info {
+            background: #bfdbfe;
+            color: #1e3a8a;
+            border: 1px solid #93c5fd;
+        }
+
+        .actions {
+            display: flex;
+            gap: 0.75rem;
+            flex-wrap: wrap;
+        }
+
+        .actions form {
+            margin-top: 0;
+        }
+
+        .muted {
+            color: #6b7280;
+            font-size: 0.9rem;
+        }
+
+        @media (prefers-color-scheme: dark) {
+            body {
+                background: #0f172a;
+            }
+
+            .panel {
+                background: #111827;
+                color: #f9fafb;
+                box-shadow: none;
+                border: 1px solid #1f2937;
+            }
+
+            h1 {
+                color: #f3f4f6;
+            }
+
+            p,
+            label,
+            .muted {
+                color: #d1d5db;
+            }
+
+            input {
+                background: #1f2937;
+                color: #f9fafb;
+                border: 1px solid #374151;
+            }
+
+            .alert.success {
+                background: rgba(22, 101, 52, 0.2);
+                border-color: rgba(22, 101, 52, 0.4);
+            }
+
+            .alert.error {
+                background: rgba(185, 28, 28, 0.25);
+                border-color: rgba(185, 28, 28, 0.4);
+                color: #fecaca;
+            }
+
+            .alert.info {
+                background: rgba(30, 64, 175, 0.2);
+                border-color: rgba(30, 64, 175, 0.4);
+                color: #bfdbfe;
+            }
+
+            .button-danger {
+                background: #dc2626;
+            }
+
+            .button-danger:hover,
+            .button-danger:focus {
+                background: #b91c1c;
+            }
+        }
+
+        a {
+            color: #2563eb;
+        }
+    </style>
+</head>
+<body>
+<div class="panel">
+    <h1>API-Key sicher hinterlegen</h1>
+
+    <p>
+        Melden Sie sich in Ihrem SumUp-Händlerkonto unter <a href="https://me.sumup.com/developers" target="_blank" rel="noreferrer noopener">developers</a> an, kopieren Sie dort den API-Key (Personal Access Token) und fügen Sie ihn unten ein.
+        Die Anwendung verschlüsselt den Schlüssel lokal und nutzt ihn anschließend automatisch für Terminal-Zahlungen.
+    </p>
+
+    <p class="muted">Angemeldet als <?= escape($authenticatedUser) ?></p>
+
+    <?php if ($storeError !== null): ?>
+        <div class="alert error">
+            <?= escape($storeError) ?>
+        </div>
+    <?php endif; ?>
+
+    <?php if ($successMessage !== null): ?>
+        <div class="alert success">
+            <?= escape($successMessage) ?>
+        </div>
+    <?php endif; ?>
+
+    <?php if ($errorMessage !== null): ?>
+        <div class="alert error">
+            <?= escape($errorMessage) ?>
+        </div>
+    <?php endif; ?>
+
+    <?php if ($store instanceof CredentialStore): ?>
+        <form method="post">
+            <label>
+                Händler-E-Mail oder Referenz (optional)
+                <input type="text" name="merchant_id" value="<?= $storedCredential !== null ? escape($storedCredential['merchant_id']) : '' ?>" placeholder="z. B. meine-filiale@example.com">
+            </label>
+
+            <label>
+                SumUp API-Key
+                <input type="password" name="api_key" autocomplete="off" placeholder="su_pk_..." required>
+            </label>
+
+            <button type="submit" name="action" value="save">API-Key speichern</button>
+        </form>
+
+        <?php if ($storedCredential !== null): ?>
+            <div class="alert info" style="margin-top: 1.5rem;">
+                <strong>Aktuell gespeicherter Schlüssel</strong>
+                <p>
+                    <?= $storedCredential['merchant_id'] !== '' ? 'Händler: ' . escape($storedCredential['merchant_id']) . '<br>' : '' ?>
+                    Zuletzt aktualisiert: <?= isset($storedCredential['updated_at']) ? escape($storedCredential['updated_at']) : 'unbekannt' ?>
+                </p>
+                <div class="actions">
+                    <form method="post" onsubmit="return confirm('Gespeicherten API-Key wirklich löschen?');">
+                        <input type="hidden" name="action" value="clear">
+                        <button type="submit" class="button-danger">API-Key löschen</button>
+                    </form>
+                    <a href="index.php">Zurück zur Kasse</a>
+                </div>
+            </div>
+        <?php else: ?>
+            <p style="margin-top: 1.5rem;">
+                Nach dem Speichern steht der Schlüssel automatisch in <a href="index.php">index.php</a> zur Verfügung.
+            </p>
+        <?php endif; ?>
+    <?php else: ?>
+        <p class="alert error">Sichere Ablage ist nicht verfügbar. Bitte beheben Sie die oben genannten Probleme.</p>
+    <?php endif; ?>
+</div>
+</body>
+</html>

--- a/public/index.php
+++ b/public/index.php
@@ -1,0 +1,681 @@
+<?php
+
+declare(strict_types=1);
+
+use SumUp\BasicAuth;
+use SumUp\CredentialStore;
+use SumUp\SumUpTerminalClient;
+
+require_once __DIR__ . '/../src/SumUpTerminalClient.php';
+require_once __DIR__ . '/../src/BasicAuth.php';
+require_once __DIR__ . '/../src/CredentialStore.php';
+
+function renderFatalError(string $message, int $statusCode = 500): void
+{
+    http_response_code($statusCode);
+    header('Content-Type: text/html; charset=UTF-8');
+
+    $safeMessage = htmlspecialchars($message, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+
+    echo <<<HTML
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="utf-8">
+    <title>Fehler – SumUp Terminal</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+        :root {
+            color-scheme: light dark;
+            font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+        }
+
+        body {
+            margin: 0;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 100vh;
+            background: #0f172a;
+            color: #f9fafb;
+            padding: 2rem;
+        }
+
+        .card {
+            background: #111827;
+            border-radius: 1rem;
+            padding: 2.5rem 2rem;
+            max-width: 32rem;
+            box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.35);
+        }
+
+        h1 {
+            margin-top: 0;
+            margin-bottom: 1rem;
+            font-size: 1.75rem;
+        }
+
+        p {
+            margin: 0;
+            line-height: 1.6;
+        }
+    </style>
+</head>
+<body>
+    <div class="card">
+        <h1>Es ist ein Fehler aufgetreten</h1>
+        <p>{$safeMessage}</p>
+    </div>
+</body>
+</html>
+HTML;
+
+    exit;
+}
+
+$configPath = __DIR__ . '/../config/config.php';
+
+if (!file_exists($configPath)) {
+    renderFatalError('Konfigurationsdatei nicht gefunden. Bitte kopieren Sie config/config.example.php nach config/config.php.');
+}
+
+/**
+ * @var mixed $config
+ */
+$config = require $configPath;
+
+if (!is_array($config)) {
+    renderFatalError('Die Konfigurationsdatei muss ein Array zurückgeben. Bitte prüfen Sie config/config.php.');
+}
+
+if (!isset($config['sumup']) || !is_array($config['sumup'])) {
+    renderFatalError('In der Konfigurationsdatei fehlt der Abschnitt "sumup". Bitte ergänzen Sie config/config.php.');
+}
+
+foreach (['auth', 'log', 'secure_store'] as $section) {
+    if (isset($config[$section]) && !is_array($config[$section])) {
+        renderFatalError(sprintf('Der Abschnitt "%s" muss ein Array sein. Bitte korrigieren Sie config/config.php.', $section));
+    }
+}
+
+/**
+ * @var array{
+ *     sumup: array{
+ *         auth_method?: string,
+ *         access_token?: string,
+ *         api_key?: string,
+ *         currency?: string,
+ *         terminal_serial?: string,
+ *         terminal_label?: string,
+ *         terminals?: array<int|string, array{serial?: string,label?: string}|string>
+ *     },
+ *     auth?: array{realm?: string, users?: array<string, string>},
+ *     log?: array{transactions_file?: string},
+ *     secure_store?: array{credential_file?: string, key_file?: string}
+ * } $config
+ */
+
+$sumUpConfig = $config['sumup'] ?? [];
+$authMethod = strtolower((string) ($sumUpConfig['auth_method'] ?? ''));
+$apiKey = trim((string) ($sumUpConfig['api_key'] ?? ''));
+$accessToken = trim((string) ($sumUpConfig['access_token'] ?? ''));
+
+$secureStoreConfig = $config['secure_store'] ?? [];
+$credentialStore = null;
+$secureStoreError = null;
+$storedCredentialDetails = null;
+
+if (isset($secureStoreConfig['credential_file'], $secureStoreConfig['key_file'])) {
+    try {
+        $credentialStore = new CredentialStore(
+            (string) $secureStoreConfig['credential_file'],
+            (string) $secureStoreConfig['key_file']
+        );
+    } catch (Throwable $storeException) {
+        $secureStoreError = $storeException->getMessage();
+    }
+}
+
+if ($authMethod === '') {
+    $authMethod = $accessToken !== '' ? 'oauth' : 'api_key';
+}
+
+if (!in_array($authMethod, ['api_key', 'oauth'], true)) {
+    renderFatalError('Ungültige SumUp-Authentifizierungsmethode. Erlaubt sind "api_key" oder "oauth".');
+}
+
+$credential = $authMethod === 'oauth' ? $accessToken : $apiKey;
+
+if ($credentialStore instanceof CredentialStore) {
+    $storedCredentialDetails = $credentialStore->getApiCredential();
+}
+
+if ($authMethod === 'api_key' && $apiKey === '' && $storedCredentialDetails !== null) {
+    $apiKey = $storedCredentialDetails['api_key'];
+    $credential = $apiKey;
+}
+
+if ($credential === '') {
+    if ($authMethod === 'oauth') {
+        renderFatalError('Kein OAuth Access Token konfiguriert. Bitte ergänzen Sie config/config.php.');
+    }
+
+    $hint = 'Kein SumUp API-Key konfiguriert. Bitte ergänzen Sie config/config.php.';
+
+    if ($credentialStore instanceof CredentialStore) {
+        $hint .= ' Alternativ können Sie Ihren Schlüssel über anmeldung.php sicher hinterlegen.';
+    }
+
+    renderFatalError($hint);
+}
+$defaultTerminalSerial = (string) ($sumUpConfig['terminal_serial'] ?? '');
+$defaultTerminalLabel = (string) ($sumUpConfig['terminal_label'] ?? '');
+$currency = (string) ($sumUpConfig['currency'] ?? 'EUR');
+
+$terminalOptions = [];
+$terminalWarnings = [];
+
+$terminalsConfig = $sumUpConfig['terminals'] ?? null;
+
+if ($terminalsConfig !== null && !is_array($terminalsConfig)) {
+    $terminalWarnings[] = 'Die Konfiguration "sumup.terminals" muss ein Array sein. Bitte prüfen Sie config/config.php.';
+}
+
+if (is_array($terminalsConfig)) {
+    foreach ($terminalsConfig as $key => $terminalConfig) {
+        $serial = '';
+        $label = '';
+
+        if (is_array($terminalConfig)) {
+            $serial = trim((string) ($terminalConfig['serial'] ?? ''));
+
+            if ($serial === '' && is_string($key) && $key !== '') {
+                $serial = trim((string) $key);
+            }
+
+            if (isset($terminalConfig['label'])) {
+                $label = trim((string) $terminalConfig['label']);
+            } elseif (is_string($key) && $key !== '' && $key !== $serial) {
+                $label = trim((string) $key);
+            }
+        } elseif (is_string($terminalConfig) || is_int($terminalConfig) || is_float($terminalConfig)) {
+            $serial = trim((string) $terminalConfig);
+            $label = is_string($key) ? trim((string) $key) : '';
+        }
+
+        if ($serial === '') {
+            $humanReadableKey = is_string($key)
+                ? sprintf('Schlüssel "%s"', $key)
+                : sprintf('Index %d', (int) $key);
+
+            $terminalWarnings[] = sprintf(
+                'Der Terminaleintrag unter %s enthält keine Seriennummer. Bitte ergänzen Sie sie in config/config.php.',
+                $humanReadableKey
+            );
+
+            continue;
+        }
+
+        if ($label === '') {
+            $label = $serial;
+        }
+
+        $terminalOptions[$serial] = $label;
+    }
+}
+
+if ($terminalOptions === [] && $defaultTerminalSerial !== '') {
+    $label = $defaultTerminalLabel !== '' ? $defaultTerminalLabel : $defaultTerminalSerial;
+    $terminalOptions[$defaultTerminalSerial] = $label;
+}
+
+if ($terminalOptions === [] && $terminalsConfig === null && $defaultTerminalSerial === '') {
+    $terminalWarnings[] = 'Es wurden noch keine Terminals konfiguriert. Öffnen Sie config/config.php und fügen Sie unter "sumup.terminals" mindestens ein Gerät hinzu (siehe config/config.example.php).';
+}
+
+$selectedTerminalSerial = array_key_first($terminalOptions) ?? '';
+$selectedTerminalLabel = $selectedTerminalSerial !== '' ? $terminalOptions[$selectedTerminalSerial] : '';
+
+$logConfig = $config['log'] ?? [];
+$transactionsLogFile = (string) ($logConfig['transactions_file'] ?? (__DIR__ . '/../var/transactions.log'));
+
+$authConfig = $config['auth'] ?? [];
+$username = BasicAuth::enforce($authConfig);
+
+$environmentErrors = [];
+
+if (!extension_loaded('curl')) {
+    $environmentErrors[] = 'Die PHP-Extension "curl" ist nicht installiert. Ohne sie können keine Zahlungsanforderungen an SumUp gesendet werden.';
+}
+
+$error = null;
+$result = null;
+$logError = null;
+
+/**
+ * @param string $logFile
+ * @param string $username
+ * @param float  $amount
+ * @param bool   $success
+ * @param string $terminalSerial
+ * @param string $terminalLabel
+ */
+function writeTransactionLog(
+    string $logFile,
+    string $username,
+    float $amount,
+    bool $success,
+    string $terminalSerial,
+    string $terminalLabel = ''
+): bool
+{
+    $directory = dirname($logFile);
+
+    if ($directory !== '' && !is_dir($directory)) {
+        if (!mkdir($directory, 0775, true) && !is_dir($directory)) {
+            return false;
+        }
+    }
+
+    $terminalInfo = '-';
+
+    if ($terminalSerial !== '') {
+        $terminalInfo = $terminalSerial;
+
+        if ($terminalLabel !== '' && $terminalLabel !== $terminalSerial) {
+            $terminalInfo = sprintf('%s (%s)', $terminalLabel, $terminalSerial);
+        }
+    }
+
+    $line = sprintf(
+        "%s\t%s\t%s\t%s\t%s\n",
+        (new DateTimeImmutable('now'))->format('c'),
+        $username !== '' ? $username : '-',
+        $terminalInfo,
+        number_format($amount, 2, '.', ''),
+        $success ? 'success' : 'failure'
+    );
+
+    return file_put_contents($logFile, $line, FILE_APPEND | LOCK_EX) !== false;
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $amount = isset($_POST['amount']) ? (float) str_replace(',', '.', (string) $_POST['amount']) : 0.0;
+    $tipAmount = isset($_POST['tip_amount']) && $_POST['tip_amount'] !== ''
+        ? (float) str_replace(',', '.', (string) $_POST['tip_amount'])
+        : null;
+    $description = isset($_POST['description']) ? trim((string) $_POST['description']) : null;
+    $requestedTerminalSerial = isset($_POST['terminal_serial']) ? trim((string) $_POST['terminal_serial']) : '';
+    $externalId = sprintf('web-%s', bin2hex(random_bytes(4)));
+
+    $paymentSuccessful = false;
+
+    if ($terminalOptions === []) {
+        $error = 'Es ist kein SumUp-Terminal konfiguriert.';
+    } elseif ($requestedTerminalSerial !== '') {
+        if (array_key_exists($requestedTerminalSerial, $terminalOptions)) {
+            $selectedTerminalSerial = $requestedTerminalSerial;
+            $selectedTerminalLabel = $terminalOptions[$requestedTerminalSerial];
+        } else {
+            $error = 'Ausgewähltes Terminal ist ungültig oder nicht konfiguriert.';
+        }
+    } elseif (count($terminalOptions) > 1) {
+        $error = 'Bitte wählen Sie ein Terminal aus.';
+    }
+
+    if ($error === null && $environmentErrors === []) {
+        try {
+            $client = new SumUpTerminalClient($credential, $selectedTerminalSerial, $authMethod);
+            $response = $client->sendPayment($amount, $currency, $externalId, $description, $tipAmount);
+
+            if ($response['status'] >= 200 && $response['status'] < 300) {
+                $paymentSuccessful = true;
+                $terminalDisplayName = $selectedTerminalLabel !== '' ? $selectedTerminalLabel : $selectedTerminalSerial;
+                $result = [
+                    'title' => 'Zahlungsanforderung gesendet',
+                    'message' => $terminalDisplayName !== ''
+                        ? sprintf(
+                            'Der Betrag wurde an das Terminal "%s" übertragen. Warten Sie auf die Bestätigung auf dem Gerät.',
+                            $terminalDisplayName
+                        )
+                        : 'Der Betrag wurde an das Terminal übertragen. Warten Sie auf die Bestätigung auf dem Gerät.',
+                    'details' => $response['body'],
+                ];
+            } else {
+                $error = sprintf(
+                    'Fehler beim Senden der Zahlungsanforderung (HTTP %d).',
+                    $response['status']
+                );
+                $result = [
+                    'title' => 'Antwort des SumUp-Servers',
+                    'details' => $response['body'],
+                ];
+            }
+        } catch (Throwable $exception) {
+            $error = $exception->getMessage();
+        }
+    }
+
+    if (!writeTransactionLog(
+        $transactionsLogFile,
+        $username,
+        $amount,
+        $paymentSuccessful,
+        $selectedTerminalSerial,
+        $selectedTerminalLabel
+    )) {
+        $logError = 'Transaktionsprotokoll konnte nicht geschrieben werden. Bitte überprüfen Sie die Schreibrechte.';
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="utf-8">
+    <title>SumUp Terminal Zahlung</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+        :root {
+            color-scheme: light dark;
+            font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+        }
+
+        body {
+            margin: 0;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 100vh;
+            background: #f6f8fb;
+        }
+
+        .container {
+            background: #fff;
+            padding: 2rem;
+            border-radius: 1rem;
+            box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.15);
+            max-width: 32rem;
+            width: 90%;
+        }
+
+        h1 {
+            margin-top: 0;
+            margin-bottom: 1.5rem;
+            font-size: 1.75rem;
+            color: #111827;
+        }
+
+        form {
+            display: grid;
+            gap: 1rem;
+        }
+
+        label {
+            display: flex;
+            flex-direction: column;
+            font-weight: 600;
+            color: #374151;
+        }
+
+        input,
+        select,
+        textarea {
+            margin-top: 0.35rem;
+            padding: 0.75rem 1rem;
+            border-radius: 0.75rem;
+            border: 1px solid #d1d5db;
+            font-size: 1rem;
+        }
+
+        textarea {
+            min-height: 4rem;
+            resize: vertical;
+        }
+
+        button {
+            background: #2563eb;
+            color: #fff;
+            border: none;
+            border-radius: 999px;
+            padding: 0.85rem 1.5rem;
+            font-size: 1rem;
+            font-weight: 600;
+            cursor: pointer;
+            transition: background 0.2s ease-in-out;
+        }
+
+        button:hover,
+        button:focus {
+            background: #1d4ed8;
+        }
+
+        .alert {
+            border-radius: 0.75rem;
+            padding: 1rem 1.25rem;
+            margin-bottom: 1rem;
+        }
+
+        .alert.error {
+            background: #fee2e2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .alert.success {
+            background: #dcfce7;
+            color: #166534;
+            border: 1px solid #bbf7d0;
+        }
+
+        .alert.info {
+            background: #bfdbfe;
+            color: #1e3a8a;
+            border: 1px solid #93c5fd;
+        }
+
+        .alert.warning {
+            background: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        pre {
+            background: #0f172a;
+            color: #e2e8f0;
+            padding: 1rem;
+            border-radius: 0.75rem;
+            overflow-x: auto;
+            font-size: 0.85rem;
+        }
+
+        @media (prefers-color-scheme: dark) {
+            body {
+                background: #0f172a;
+            }
+
+            .container {
+                background: #111827;
+                color: #f9fafb;
+                box-shadow: none;
+                border: 1px solid #1f2937;
+            }
+
+            h1 {
+                color: #f3f4f6;
+            }
+
+            label {
+                color: #d1d5db;
+            }
+
+            input,
+            select,
+            textarea {
+                background: #1f2937;
+                color: #f9fafb;
+                border: 1px solid #374151;
+            }
+
+            .alert.success {
+                background: rgba(22, 101, 52, 0.2);
+                border-color: rgba(22, 101, 52, 0.4);
+            }
+
+            .alert.info {
+                background: rgba(30, 64, 175, 0.2);
+                border-color: rgba(30, 64, 175, 0.4);
+                color: #bfdbfe;
+            }
+
+            .alert.warning {
+                background: rgba(217, 119, 6, 0.2);
+                border-color: rgba(217, 119, 6, 0.4);
+                color: #fef3c7;
+            }
+
+            .alert.error {
+                background: rgba(153, 27, 27, 0.2);
+                border-color: rgba(153, 27, 27, 0.4);
+            }
+
+            pre {
+                background: #1e293b;
+                color: #e2e8f0;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>SumUp Zahlung starten</h1>
+
+        <?php if ($authMethod === 'api_key'): ?>
+            <?php if ($secureStoreError !== null): ?>
+                <div class="alert error">
+                    <strong>Sichere Ablage deaktiviert:</strong>
+                    <div><?= htmlspecialchars($secureStoreError, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?></div>
+                </div>
+            <?php elseif ($credentialStore instanceof CredentialStore && $storedCredentialDetails !== null): ?>
+                <div class="alert info">
+                    <strong>API-Key geladen</strong>
+                    <p>
+                        Der hinterlegte Schlüssel<?= $storedCredentialDetails['merchant_id'] !== ''
+                            ? ' für ' . htmlspecialchars($storedCredentialDetails['merchant_id'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8')
+                            : '' ?> wurde automatisch verwendet.
+                        <?php if (isset($storedCredentialDetails['updated_at']) && $storedCredentialDetails['updated_at'] !== ''): ?>
+                            <br>
+                            Zuletzt aktualisiert: <?= htmlspecialchars($storedCredentialDetails['updated_at'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>
+                        <?php endif; ?>
+                    </p>
+                </div>
+            <?php elseif ($credentialStore instanceof CredentialStore): ?>
+                <div class="alert info">
+                    <strong>API-Key hinterlegen</strong>
+                    <p>
+                        Besuchen Sie <a href="anmeldung.php">anmeldung.php</a>, um Ihren SumUp API-Key sicher zu speichern.
+                    </p>
+                </div>
+            <?php endif; ?>
+        <?php endif; ?>
+        <?php foreach ($terminalWarnings as $terminalWarning): ?>
+            <div class="alert warning">
+                <strong>Konfiguration:</strong>
+                <div><?= htmlspecialchars($terminalWarning, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?></div>
+            </div>
+        <?php endforeach; ?>
+
+        <?php foreach ($environmentErrors as $envError): ?>
+            <div class="alert error">
+                <strong>Systemvoraussetzung:</strong>
+                <div><?= htmlspecialchars($envError, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?></div>
+            </div>
+        <?php endforeach; ?>
+
+        <?php if ($error !== null): ?>
+            <div class="alert error">
+                <strong>Fehler:</strong>
+                <div><?= htmlspecialchars($error, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?></div>
+            </div>
+        <?php elseif ($result !== null): ?>
+            <div class="alert success">
+                <strong><?= htmlspecialchars($result['title'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?></strong>
+                <p><?= htmlspecialchars($result['message'] ?? '', ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?></p>
+            </div>
+        <?php endif; ?>
+
+        <?php if ($logError !== null): ?>
+            <div class="alert error">
+                <strong>Protokollierung:</strong>
+                <div><?= htmlspecialchars($logError, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?></div>
+            </div>
+        <?php endif; ?>
+
+        <form method="post">
+            <?php if ($terminalOptions === []): ?>
+                <label>
+                    Terminal
+                    <select name="terminal_serial" disabled>
+                        <option>Bitte konfigurieren Sie mindestens ein Terminal</option>
+                    </select>
+                </label>
+            <?php else: ?>
+                <label>
+                    Terminal
+                    <select name="terminal_serial">
+                        <?php foreach ($terminalOptions as $serial => $label): ?>
+                            <option value="<?= htmlspecialchars($serial, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>"<?= $serial === $selectedTerminalSerial ? ' selected' : '' ?>>
+                                <?= htmlspecialchars($label, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>
+                            </option>
+                        <?php endforeach; ?>
+                    </select>
+                </label>
+            <?php endif; ?>
+
+            <label>
+                Rechnungsbetrag (<?= htmlspecialchars($currency, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>)
+                <input
+                    type="number"
+                    name="amount"
+                    min="0"
+                    step="0.01"
+                    placeholder="z. B. 19.99"
+                    value="<?= isset($_POST['amount']) ? htmlspecialchars((string) $_POST['amount'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') : '' ?>"
+                    required
+                >
+            </label>
+
+            <label>
+                Trinkgeld (optional)
+                <input
+                    type="number"
+                    name="tip_amount"
+                    min="0"
+                    step="0.01"
+                    placeholder="z. B. 2.00"
+                    value="<?= isset($_POST['tip_amount']) ? htmlspecialchars((string) $_POST['tip_amount'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') : '' ?>"
+                >
+            </label>
+
+            <label>
+                Beschreibung (optional)
+                <textarea name="description" placeholder="Referenz oder Notiz"><?= isset($_POST['description']) ? htmlspecialchars((string) $_POST['description'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') : '' ?></textarea>
+            </label>
+
+            <button type="submit"<?= $terminalOptions === [] || $environmentErrors !== [] ? ' disabled' : '' ?>>An Terminal senden</button>
+        </form>
+
+        <?php if ($result !== null): ?>
+            <details>
+                <summary>Antwortdetails</summary>
+                <pre><?= htmlspecialchars(json_encode($result['details'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE), ENT_NOQUOTES | ENT_SUBSTITUTE, 'UTF-8') ?></pre>
+            </details>
+        <?php endif; ?>
+
+        <?php if ($accessToken === '' || $terminalOptions === []): ?>
+            <p class="alert error">
+                Bitte hinterlegen Sie den Zugriffstoken und mindestens ein Terminal in <code>config/config.php</code>.
+            </p>
+        <?php endif; ?>
+    </div>
+</body>
+</html>

--- a/src/BasicAuth.php
+++ b/src/BasicAuth.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SumUp;
+
+final class BasicAuth
+{
+    /**
+     * @param array{realm?: string, users?: array<string, string>} $authConfig
+     * @return string authenticated username
+     */
+    public static function enforce(array $authConfig): string
+    {
+        $realm = isset($authConfig['realm']) ? (string) $authConfig['realm'] : 'SumUp Terminal';
+        $users = $authConfig['users'] ?? [];
+
+        if ($users === []) {
+            self::renderHtmlError('Keine Benutzer für den Zugriff konfiguriert. Bitte ergänzen Sie config/config.php.', 500);
+        }
+
+        $authenticated = false;
+        $username = '';
+
+        if (isset($_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW'])) {
+            $username = (string) $_SERVER['PHP_AUTH_USER'];
+            $password = (string) $_SERVER['PHP_AUTH_PW'];
+
+            if (array_key_exists($username, $users)) {
+                $storedHash = (string) $users[$username];
+                $authenticated = password_verify($password, $storedHash)
+                    || hash_equals($storedHash, $password);
+            }
+        }
+
+        if ($authenticated === false) {
+            header('WWW-Authenticate: Basic realm="' . addslashes($realm) . '", charset="UTF-8"');
+            self::renderHtmlError('Authentifizierung erforderlich.', 401);
+        }
+
+        return $username;
+    }
+
+    private static function renderHtmlError(string $message, int $statusCode): void
+    {
+        http_response_code($statusCode);
+        header('Content-Type: text/html; charset=UTF-8');
+
+        $safeMessage = htmlspecialchars($message, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+
+        echo <<<HTML
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="utf-8">
+    <title>Zugriff geschützt</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+        :root {
+            color-scheme: light dark;
+            font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+        }
+
+        body {
+            margin: 0;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 100vh;
+            background: #0f172a;
+            color: #f9fafb;
+            padding: 2rem;
+        }
+
+        .card {
+            background: #111827;
+            border-radius: 1rem;
+            padding: 2.5rem 2rem;
+            max-width: 32rem;
+            text-align: center;
+            box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.35);
+        }
+
+        h1 {
+            margin-top: 0;
+            margin-bottom: 1rem;
+            font-size: 1.75rem;
+        }
+
+        p {
+            margin: 0;
+            line-height: 1.6;
+        }
+    </style>
+</head>
+<body>
+    <div class="card">
+        <h1>Zugriff verweigert</h1>
+        <p>{$safeMessage}</p>
+    </div>
+</body>
+</html>
+HTML;
+
+        exit;
+    }
+}

--- a/src/CredentialStore.php
+++ b/src/CredentialStore.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SumUp;
+
+use RuntimeException;
+
+final class CredentialStore
+{
+    private string $credentialFile;
+    private string $keyFile;
+
+    public function __construct(string $credentialFile, string $keyFile)
+    {
+        if (!extension_loaded('sodium')) {
+            throw new RuntimeException('Die PHP-Extension "sodium" wird für die sichere Speicherung benötigt.');
+        }
+
+        $this->credentialFile = $credentialFile;
+        $this->keyFile = $keyFile;
+    }
+
+    public function hasApiKey(): bool
+    {
+        $data = $this->readCredentialFile();
+
+        return isset($data['ciphertext'], $data['nonce']) && $data['ciphertext'] !== '' && $data['nonce'] !== '';
+    }
+
+    /**
+     * @return array{merchant_id: string, api_key: string, updated_at?: string}|null
+     */
+    public function getApiCredential(): ?array
+    {
+        $data = $this->readCredentialFile();
+
+        if (!isset($data['ciphertext'], $data['nonce'])) {
+            return null;
+        }
+
+        $ciphertext = base64_decode((string) $data['ciphertext'], true);
+        $nonce = base64_decode((string) $data['nonce'], true);
+
+        if ($ciphertext === false || $nonce === false) {
+            return null;
+        }
+
+        $key = $this->loadOrCreateKey();
+        $apiKey = sodium_crypto_secretbox_open($ciphertext, $nonce, $key);
+
+        if ($apiKey === false) {
+            return null;
+        }
+
+        $result = [
+            'merchant_id' => isset($data['merchant_id']) ? (string) $data['merchant_id'] : '',
+            'api_key' => $apiKey,
+        ];
+
+        if (isset($data['updated_at'])) {
+            $result['updated_at'] = (string) $data['updated_at'];
+        }
+
+        return $result;
+    }
+
+    public function saveApiKey(string $merchantId, string $apiKey): void
+    {
+        $merchantId = trim($merchantId);
+        $apiKey = trim($apiKey);
+
+        if ($apiKey === '') {
+            throw new RuntimeException('API-Key darf nicht leer sein.');
+        }
+
+        $key = $this->loadOrCreateKey();
+        $nonce = random_bytes(SODIUM_CRYPTO_SECRETBOX_NONCEBYTES);
+        $ciphertext = sodium_crypto_secretbox($apiKey, $nonce, $key);
+
+        $payload = [
+            'merchant_id' => $merchantId,
+            'nonce' => base64_encode($nonce),
+            'ciphertext' => base64_encode($ciphertext),
+            'updated_at' => (new \DateTimeImmutable('now'))->format('c'),
+        ];
+
+        $this->writeCredentialFile($payload);
+    }
+
+    public function clear(): void
+    {
+        if (is_file($this->credentialFile)) {
+            unlink($this->credentialFile);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readCredentialFile(): array
+    {
+        if (!is_file($this->credentialFile)) {
+            return [];
+        }
+
+        $content = file_get_contents($this->credentialFile);
+
+        if ($content === false || $content === '') {
+            return [];
+        }
+
+        $data = json_decode($content, true);
+
+        return is_array($data) ? $data : [];
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function writeCredentialFile(array $payload): void
+    {
+        $directory = dirname($this->credentialFile);
+
+        if ($directory !== '' && !is_dir($directory)) {
+            if (!mkdir($directory, 0700, true) && !is_dir($directory)) {
+                throw new RuntimeException('Speicherverzeichnis konnte nicht erstellt werden: ' . $directory);
+            }
+        }
+
+        $json = json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+
+        if ($json === false) {
+            throw new RuntimeException('API-Key konnte nicht serialisiert werden.');
+        }
+
+        if (file_put_contents($this->credentialFile, $json . "\n", LOCK_EX) === false) {
+            throw new RuntimeException('API-Key konnte nicht gespeichert werden.');
+        }
+
+        chmod($this->credentialFile, 0600);
+    }
+
+    /**
+     * @return string
+     */
+    private function loadOrCreateKey(): string
+    {
+        if (is_file($this->keyFile)) {
+            $key = file_get_contents($this->keyFile);
+
+            if ($key !== false && strlen($key) === SODIUM_CRYPTO_SECRETBOX_KEYBYTES) {
+                return $key;
+            }
+        }
+
+        $directory = dirname($this->keyFile);
+
+        if ($directory !== '' && !is_dir($directory)) {
+            if (!mkdir($directory, 0700, true) && !is_dir($directory)) {
+                throw new RuntimeException('Schlüsselverzeichnis konnte nicht erstellt werden: ' . $directory);
+            }
+        }
+
+        $key = random_bytes(SODIUM_CRYPTO_SECRETBOX_KEYBYTES);
+
+        if (file_put_contents($this->keyFile, $key, LOCK_EX) === false) {
+            throw new RuntimeException('Schlüssel konnte nicht gespeichert werden.');
+        }
+
+        chmod($this->keyFile, 0600);
+
+        return $key;
+    }
+}

--- a/src/SumUpTerminalClient.php
+++ b/src/SumUpTerminalClient.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SumUp;
+
+use RuntimeException;
+
+final class SumUpTerminalClient
+{
+    private const API_BASE_URL = 'https://api.sumup.com/v0.1';
+
+    public function __construct(
+        private readonly string $credential,
+        private readonly string $terminalSerial,
+        private readonly string $authMethod = 'api_key'
+    ) {
+        if (!in_array($this->authMethod, ['api_key', 'oauth'], true)) {
+            throw new RuntimeException('Unsupported SumUp authentication method.');
+        }
+
+        if ($credential === '') {
+            throw new RuntimeException('Missing SumUp credentials.');
+        }
+
+        if ($terminalSerial === '') {
+            throw new RuntimeException('Missing SumUp terminal serial number.');
+        }
+    }
+
+    /**
+     * Sends a payment request to the configured SumUp terminal.
+     *
+     * @param float       $amount       Amount in major units (e.g. Euros).
+     * @param string      $currency     ISO 4217 currency code, e.g. "EUR".
+     * @param string|null $externalId   Optional unique identifier for the payment.
+     * @param string|null $description  Optional description that appears in SumUp dashboard.
+     * @param float|null  $tipAmount    Optional tip amount in major units.
+     *
+     * @return array{status:int, body:array<string,mixed>}
+     */
+    public function sendPayment(
+        float $amount,
+        string $currency = 'EUR',
+        ?string $externalId = null,
+        ?string $description = null,
+        ?float $tipAmount = null
+    ): array {
+        if ($amount <= 0) {
+            throw new RuntimeException('Amount must be greater than zero.');
+        }
+
+        $payload = [
+            'amount' => round($amount, 2),
+            'currency' => strtoupper($currency),
+            'transaction_type' => 'SALE',
+        ];
+
+        if ($tipAmount !== null) {
+            $payload['tip_amount'] = round($tipAmount, 2);
+        }
+
+        if ($externalId !== null && $externalId !== '') {
+            $payload['external_id'] = $externalId;
+        }
+
+        if ($description !== null && $description !== '') {
+            $payload['description'] = $description;
+        }
+
+        $endpoint = sprintf(
+            '%s/terminals/%s/transactions',
+            self::API_BASE_URL,
+            rawurlencode($this->terminalSerial)
+        );
+
+        return $this->postJson($endpoint, $payload);
+    }
+
+    /**
+     * @param array<string,mixed> $payload
+     * @return array{status:int, body:array<string,mixed>}
+     */
+    private function postJson(string $url, array $payload): array
+    {
+        if (!extension_loaded('curl')) {
+            throw new RuntimeException('Die PHP-Extension "curl" wird für die Kommunikation mit SumUp benötigt.');
+        }
+
+        $ch = curl_init($url);
+        if ($ch === false) {
+            throw new RuntimeException('Unable to initialise cURL.');
+        }
+
+        $encodedPayload = json_encode($payload, JSON_THROW_ON_ERROR);
+
+        curl_setopt_array($ch, [
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_POST => true,
+            CURLOPT_POSTFIELDS => $encodedPayload,
+            CURLOPT_HTTPHEADER => [
+                'Content-Type: application/json',
+                'Accept: application/json',
+                sprintf('Authorization: %s', $this->buildAuthorizationHeader()),
+            ],
+        ]);
+
+        $responseBody = curl_exec($ch);
+        if ($responseBody === false) {
+            $message = curl_error($ch);
+            curl_close($ch);
+            throw new RuntimeException('SumUp API request failed: ' . $message);
+        }
+
+        $statusCode = curl_getinfo($ch, CURLINFO_RESPONSE_CODE) ?: 0;
+        curl_close($ch);
+
+        /** @var array<string,mixed>|null $decoded */
+        $decoded = json_decode($responseBody, true);
+        if (!is_array($decoded)) {
+            $decoded = [
+                'raw' => $responseBody,
+            ];
+        }
+
+        return [
+            'status' => $statusCode,
+            'body' => $decoded,
+        ];
+    }
+
+    private function buildAuthorizationHeader(): string
+    {
+        // SumUp accepts API keys and OAuth tokens via Bearer authorization.
+        return 'Bearer ' . $this->credential;
+    }
+}

--- a/var/.gitignore
+++ b/var/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
## Summary
- detect invalid or missing `sumup.terminals` entries and surface descriptive warnings above the form
- style configuration notices separately from system requirement alerts for clarity
- document that the dashboard now shows yellow configuration hints when no terminals appear

## Testing
- php -l public/index.php

------
https://chatgpt.com/codex/tasks/task_e_68db9b2aade0833392f49c7b5279b3e2